### PR TITLE
Add deferred diagnostics when AUX builtins appear in device code

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10878,4 +10878,6 @@ def err_ext_int_bad_size : Error<"%select{signed|unsigned}0 _ExtInt must "
                                  "have a bit size of at least %select{2|1}0">;
 def err_ext_int_max_size : Error<"%select{signed|unsigned}0 _ExtInt of bit "
                                  "sizes greater than %1 not supported">;
+def err_aux_target_builtin_in_device_code : Error<
+  "AUX target specific builtins should not be present in device code">;                                 
 } // end of sema component.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1938,24 +1938,17 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     if (Context.BuiltinInfo.isAuxBuiltinID(BuiltinID)) {
       assert(Context.getAuxTargetInfo() &&
              "Aux Target Builtin, but not an aux target?");
-      /*
-      'CheckTSBuiltinFunctionCall' function checks for an aux-target builtin and also validates it 
-      against the correct target. */
+      
       if (CheckTSBuiltinFunctionCall(
               Context.getAuxTargetInfo()->getTriple().getArch(),
               Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall)) {
-                /*At this point, we know that the builtin is an aux-builtin and also checked.
-                  AUX builtins are not allowed to appear inside device code.
-                  To handle this, we use the notion of "deferred diagnostics", where we are compiling
-                  for the device, but we don't know that this function will be codegen'ed
-                  for device yet. So we create a diagnostic which is emitted if and when we
-                  realize that the function will be codegen'ed
-                */
-                if (getLangOpts().SYCLIsDevice) {
-                    SYCLDiagIfDeviceCode(TheCall->getBeginLoc(), diag::err_aux_target_builtin_in_device_code);
+                    
                     return ExprError();
-                }
-              }
+      } else {
+        if(getLangOpts().SYCLIsDevice) {
+          SYCLDiagIfDeviceCode(TheCall->getBeginLoc(), diag::err_aux_target_builtin_in_device_code);
+        }
+      }
         
     } else {
       if (CheckTSBuiltinFunctionCall(

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1945,6 +1945,15 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
                     
                     return ExprError();
       } else {
+        /*
+        Parameters of the AUX built-in function have been validated and have no errors.
+        Device code is not allowed to have the AUX built-ins in them.
+        To handle this we use SYCLDiagIfDeviceCode, which creates a DeviceDiagBuilder that emits 
+        the diagnostic if the current context is "used as device code".
+        We first detect if we are compiling for device. But we don't know that this function will be codegen'ed
+        for device yet.So we create a diagnostic which is emitted if and when we realize that the function 
+        will be codegen'ed
+        */
         if(getLangOpts().SYCLIsDevice) {
           SYCLDiagIfDeviceCode(TheCall->getBeginLoc(), diag::err_aux_target_builtin_in_device_code);
         }

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -1938,27 +1938,24 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
     if (Context.BuiltinInfo.isAuxBuiltinID(BuiltinID)) {
       assert(Context.getAuxTargetInfo() &&
              "Aux Target Builtin, but not an aux target?");
-      
       if (CheckTSBuiltinFunctionCall(
               Context.getAuxTargetInfo()->getTriple().getArch(),
               Context.BuiltinInfo.getAuxBuiltinID(BuiltinID), TheCall)) {
                     
-                    return ExprError();
-      } else {
-        /*
-        Parameters of the AUX built-in function have been validated and have no errors.
-        Device code is not allowed to have the AUX built-ins in them.
-        To handle this we use SYCLDiagIfDeviceCode, which creates a DeviceDiagBuilder that emits 
-        the diagnostic if the current context is "used as device code".
-        We first detect if we are compiling for device. But we don't know that this function will be codegen'ed
-        for device yet.So we create a diagnostic which is emitted if and when we realize that the function 
-        will be codegen'ed
-        */
-        if(getLangOpts().SYCLIsDevice) {
-          SYCLDiagIfDeviceCode(TheCall->getBeginLoc(), diag::err_aux_target_builtin_in_device_code);
-        }
+              return ExprError();
       }
-        
+      /*
+      Parameters of the AUX built-in function have been validated and have no errors.
+      Device code is not allowed to have the AUX built-ins in them.
+      To handle this we use SYCLDiagIfDeviceCode, which creates a DeviceDiagBuilder that emits 
+      the diagnostic if the current context is "used as device code".
+      We first detect if we are compiling for device. But we don't know that this function will be codegen'ed
+      for device yet.So we create a diagnostic which is emitted if and when we realize that the function 
+      will be codegen'ed
+      */
+      if(getLangOpts().SYCLIsDevice) {
+        SYCLDiagIfDeviceCode(TheCall->getBeginLoc(), diag::err_aux_target_builtin_in_device_code);
+      }
     } else {
       if (CheckTSBuiltinFunctionCall(
               Context.getTargetInfo().getTriple().getArch(), BuiltinID,

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -2,8 +2,6 @@
 // 
 //
 // Ensure that the SYCL diagnostics that are typically deferred are correctly emitted.
-#include <x86intrin.h>
-
 namespace std {
 class type_info;
 typedef __typeof__(sizeof(int)) size_t;
@@ -24,16 +22,17 @@ __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
 void calledFromHost(void) {
   //These built-in functions are available for the x86-32 and x86-64 family of computers
   //This function returns a positive integer if the run-time CPU is of type cpuname and returns 0 otherwise.
-  __builtin_cpu_is(“skylake”);
+
+  __builtin_cpu_is("intel");
 }
 
 void calledFromHostWithInvalidBuiltinParam(void) {
-  __builtin_cpu_is(“testInvalidCPU”);
+  __builtin_cpu_is("testInvalidCPU");
 }
 
 // 
 void calledFromKernel(void) {
-  __builtin_cpu_is(“skylake”);
+  __builtin_cpu_is("skylake");
 }
 
 int main(int argc, char **argv) {

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -13,6 +13,7 @@ namespace sycl {
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  // expected-note@+1 {{called by 'kernel_single_task<AName, (lambda}}
   kernelFunc();
 }
 
@@ -23,28 +24,27 @@ void calledFromHost(void) {
   //These built-in functions are available for the x86-32 and x86-64 family of computers
   //This function returns a positive integer if the run-time CPU is of type cpuname and returns 0 otherwise.
 
-  __builtin_cpu_is("intel");
+  //__builtin_cpu_is("intel");
+  __builtin_cpu_init ();
 }
 
 void calledFromHostWithInvalidBuiltinParam(void) {
-  __builtin_cpu_is("testInvalidCPU");
+  //__builtin_cpu_is("testInvalidCPU");
 }
 
 // 
-void calledFromKernel(void) {
-  __builtin_cpu_is("skylake");
-}
+
 
 int main(int argc, char **argv) {
 
   //This is host code. This will not be compiled for the device.
-  calledFromHost();
+  //calledFromHost();
 
   //calledFromHostWithInvalidBuiltinParam();
   
   cl::sycl::kernel_single_task<class AName>([]() {
     //SYCL device compiler will compile this kernel for a device as well as any functions that the kernel calls
-    calledFromKernel(); //expected-error {{ Device code must not have aux builtins in them }}
+    __builtin_cpu_init (); // expected-error {{ AUX target specific builtins should not be present in device code }}
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown-sycldevice -fsycl -fsycl-is-device -aux-triple x86_64-unknown-linux-gnu -verify -fsyntax-only  %s
+// 
+//
+// Ensure that the SYCL diagnostics that are typically deferred are correctly emitted.
+#include <x86intrin.h>
+
+namespace std {
+class type_info;
+typedef __typeof__(sizeof(int)) size_t;
+} // namespace std
+
+// testing that the deferred diagnostics work in conjunction with the SYCL namespaces.
+inline namespace cl {
+namespace sycl {
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel_single_task(Func kernelFunc) {
+  kernelFunc();
+}
+
+} // namespace sycl
+} // namespace cl
+
+void calledFromHost(void) {
+  //These built-in functions are available for the x86-32 and x86-64 family of computers
+  //This function returns a positive integer if the run-time CPU is of type cpuname and returns 0 otherwise.
+  __builtin_cpu_is(“skylake”);
+}
+
+void calledFromHostWithInvalidBuiltinParam(void) {
+  __builtin_cpu_is(“testInvalidCPU”);
+}
+
+// 
+void calledFromKernel(void) {
+  __builtin_cpu_is(“skylake”);
+}
+
+int main(int argc, char **argv) {
+
+  //This is host code. This will not be compiled for the device.
+  calledFromHost();
+
+  //calledFromHostWithInvalidBuiltinParam();
+  
+  cl::sycl::kernel_single_task<class AName>([]() {
+    //SYCL device compiler will compile this kernel for a device as well as any functions that the kernel calls
+    calledFromKernel(); //expected-error {{ Device code must not have aux builtins in them }}
+  });
+  return 0;
+}


### PR DESCRIPTION
If a sycl application has host code with target specific builtins and the device code is compiled for a different target, then the SYCL device compiler will compile both host and device source code and the resulting device build will have the SPIRV target triple, as well as the host’s target triple as an ‘aux-triple’   

We must make sure that this does not get codegen'ed. So we detect any AUX target builtins in device code and use the notion of deferred diagnostics where we are compiling for the device, but we don't know that this function will be codegen'ed for device yet. So we  create a diagnostic which is emitted if and when  the function will be codegen'ed.