### PR TITLE
Prevent compilation failure if a no-prototype function is not called from SYCL Kernel

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9371,8 +9371,9 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
         // (void) parameters, so we relax this to a warning.
         int DiagID =
             CC == CC_X86StdCall ? diag::warn_cconv_knr : diag::err_cconv_knr;
-        Diag(NewFD->getLocation(), DiagID)
-            << FunctionType::getNameForCallConv(CC);
+        if(!getLangOpts().SYCL && !getLangOpts().SYCLIsDevice)
+          Diag(NewFD->getLocation(), DiagID)
+              << FunctionType::getNameForCallConv(CC);
       }
     }
 


### PR DESCRIPTION
- In C language, declaring a function without any information about its
  parameters allows the function to be called with any arguments.
- However, SYCL kernel does not support calling of no-prototype functions
  and emits an error.
- But if a no-prototype function is not called from a SYCL kernel,
  then we should stop emitting the error.