### PR TITLE
Prevent compilation failure if a function is not called from SYCL Kernel

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9371,8 +9371,9 @@ Sema::ActOnFunctionDeclarator(Scope *S, Declarator &D, DeclContext *DC,
         // (void) parameters, so we relax this to a warning.
         int DiagID =
             CC == CC_X86StdCall ? diag::warn_cconv_knr : diag::err_cconv_knr;
-        Diag(NewFD->getLocation(), DiagID)
-            << FunctionType::getNameForCallConv(CC);
+        if(getLangOpts().SYCLIsDevice)
+          SYCLDiagIfDeviceCode(D.getIdentifierLoc(), DiagID)
+              << FunctionType::getNameForCallConv(CC);
       }
     }
 

--- a/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
+++ b/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
@@ -24,6 +24,8 @@ int __declspec(dllexport) foo(int a) {
   return a;
 }
 
+int __declspec(dllexport) test();
+
 // CHECK: warning: __declspec attribute 'dllimport' is not supported
 int __declspec(dllimport) bar();
 
@@ -42,7 +44,8 @@ int  __declspec(dllexport) foo(int a) {
 }
 // expected-note@+1 {{'bar' declared here}}
 SYCL_EXTERNAL int __declspec(dllimport) bar();
-// expected-note@+2 {{previous attribute is here}}
+SYCL_EXTERNAL int __declspec(dllexport) xyz();
+  // expected-note@+2 {{previous attribute is here}}
 // expected-note@+1 {{previous declaration is here}}
 int __declspec(dllimport) foobar();
 int foobar()  // expected-warning {{'foobar' redeclared without 'dllimport' attribute: previous 'dllimport' ignored}}
@@ -62,6 +65,8 @@ int main() {
     foo(10);// expected-no-error
     bar(); // expected-error {{SYCL kernel cannot call a dllimport function}}
     foobar(); // expected-no-error
+    xyz();
+    test();
   });
   bar();  // expected-no-error
   return 0;


### PR DESCRIPTION
•	In C language, declaring a function without any information about its parameters allows the function to be called with any arguments.
•	However, SYCL kernel does not support calling of no-prototype functions and therefore emits an error.
(This could be possibly  due to this requirement from spec
Per SYCL 1.2.1 spec:
In order for the SYCL device compiler to correctly compile device functions, all functions in the source file,
whether device functions or not, must be syntactically correct functions according to this specification. 
A syntactically correct function is a function that matches at least the C++11 specification, plus any extensions from the
C++14 specification.)
•	This PR checks if we are compiling code for a SYCL device and emits a deferred diagnostics if and only if a no-prototype function is called from SYCL kernel
